### PR TITLE
Fix: Return error response when AI call fails instead of masking it

### DIFF
--- a/ai_generator.py
+++ b/ai_generator.py
@@ -168,11 +168,30 @@ class AIResponseGenerator:
                     error=error_msg,
                     duration=duration
                 )
-                raise
+
+                # 返回错误响应而不是抛出异常
+                return {
+                    "success": False,
+                    "error": "AI generation failed",
+                    "error_detail": error_msg,
+                    "code": 500,
+                    "app": app_name,
+                    "action": action,
+                    "fallback": "Consider using default response or check AI configuration"
+                }
 
         except Exception as e:
             mcp_logger.error(f"AI generation failed: {e}", exc_info=True)
-            return self._generate_default_response(app_name, action, parameters)
+            # 返回错误响应而不是默认成功响应
+            return {
+                "success": False,
+                "error": "AI generation failed",
+                "error_detail": str(e),
+                "code": 500,
+                "app": app_name,
+                "action": action,
+                "fallback": "Consider using default response or check AI configuration"
+            }
 
     def _generate_default_response(self, app_name: str, action: str, parameters: Dict[str, Any]) -> Dict[str, Any]:
         """生成默认响应"""

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -274,7 +274,8 @@ def handle_mcp_request(data: dict, session_id: str = None, app_context: dict = N
                 )
 
                 # 判断是否成功
-                success = 'error' not in result or result.get('code', 200) < 400
+                # 成功条件：没有error字段 且 (没有code字段或code < 400)
+                success = 'error' not in result and result.get('code', 200) < 400
 
                 # 记录工具调用
                 mcp_logger.log_tool_call(


### PR DESCRIPTION
Previously, when AI generation failed (e.g., stream mode required but not enabled), the system would mask the error and return a default success response, making it impossible to diagnose issues.

Changes:
- ai_generator.py: Return error response with details instead of raising exception or falling back to default success response
- mcp_server.py: Fix success判断逻辑 from 'or' to 'and' to correctly identify failures
- Error response includes: success=False, error, error_detail, code=500, and fallback hint

Now when AI fails (like qwq-32b requiring stream mode), the MCP tool call result will properly show the error instead of showing "SUCCESS" in logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)