### PR TITLE
Feat: 同步v2.11.0多LLM配置管理功能至OEM分支

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.11.0] - 2025-12-12
+
+### Added
+- Multi-LLM configuration management
+  - Pre-register multiple LLM configurations for different providers/models
+  - Card list view displaying all configs with active indicator
+  - Add/edit/delete configurations via modal dialog
+  - One-click activation to switch between configs
+  - Auto-enable first config when only one exists
+- Hot config switching across processes
+  - MCP Server automatically detects config changes from database
+  - No server restart required when switching LLM configs
+- Enhanced JSON response parsing
+  - Support for multiple JSON objects (extract first valid object)
+  - Handle "Extra data" format issues from some LLM providers
+  - Better markdown code block cleanup
+
+### Fixed
+- SQLAlchemy session error when updating LLM config (`Instance not bound to Session`)
+- Test connection now uses correct API Key from specific config (not just active config)
+- API Key not updated when unchanged (masked format detection)
+- Empty response hint for reasoning models (suggest enabling Stream mode)
+
+### Changed
+- Test connection button shows "Testing..." and disabled state during request
+- Improved error messages with model name and stream status for debugging
+
 ## [2.10.1] - 2025-12-12
 
 ### Added
@@ -233,7 +260,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - SQLite database with SQLAlchemy ORM
 - Comprehensive test coverage
 
-[Unreleased]: https://github.com/flagify-com/UniMCPSim/compare/v2.10.1...HEAD
+[Unreleased]: https://github.com/flagify-com/UniMCPSim/compare/v2.11.0...HEAD
+[2.11.0]: https://github.com/flagify-com/UniMCPSim/compare/v2.10.1...v2.11.0
 [2.10.1]: https://github.com/flagify-com/UniMCPSim/compare/v2.10.0...v2.10.1
 [2.10.0]: https://github.com/flagify-com/UniMCPSim/compare/v2.9.0...v2.10.0
 [2.9.0]: https://github.com/flagify-com/UniMCPSim/compare/v2.6.0...v2.9.0

--- a/templates/llm_config.html
+++ b/templates/llm_config.html
@@ -6,384 +6,585 @@
     <title>大模型配置 - UniMCPSim</title>
     <link rel="stylesheet" href="/static/css/main.css">
     <style>
+        .config-list {
+            display: flex;
+            flex-direction: column;
+            gap: 1rem;
+        }
+        .config-card {
+            border: 1px solid var(--bg-300);
+            border-radius: 8px;
+            padding: 1rem 1.25rem;
+            background: var(--bg-100);
+            transition: box-shadow 0.2s;
+        }
+        .config-card:hover {
+            box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+        }
+        .config-card.active {
+            border-color: var(--success);
+            border-width: 2px;
+        }
+        .config-header {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            margin-bottom: 0.5rem;
+        }
+        .config-title {
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+            font-weight: 600;
+            font-size: 1.1rem;
+        }
+        .config-title .status-icon {
+            font-size: 1.2rem;
+        }
+        .config-title .active-badge {
+            background: var(--success);
+            color: white;
+            font-size: 0.75rem;
+            padding: 0.15rem 0.5rem;
+            border-radius: 4px;
+            font-weight: normal;
+        }
+        .config-actions {
+            display: flex;
+            gap: 0.5rem;
+        }
+        .config-actions .btn {
+            padding: 0.25rem 0.75rem;
+            font-size: 0.85rem;
+        }
+        .config-details {
+            font-size: 0.9rem;
+            color: var(--text-200);
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5rem 2rem;
+            align-items: center;
+        }
+        .config-details .detail-item {
+            display: flex;
+            align-items: center;
+            gap: 0.25rem;
+            white-space: nowrap;
+        }
+        .empty-state {
+            text-align: center;
+            padding: 3rem;
+            color: var(--text-200);
+            border: 2px dashed var(--bg-300);
+            border-radius: 8px;
+        }
+        .empty-state p {
+            margin-bottom: 1rem;
+        }
+        /* Modal styles */
+        .modal-overlay {
+            display: none;
+            position: fixed;
+            top: 0;
+            left: 0;
+            right: 0;
+            bottom: 0;
+            background: rgba(0,0,0,0.5);
+            z-index: 1000;
+            align-items: center;
+            justify-content: center;
+        }
+        .modal-overlay.show {
+            display: flex;
+        }
+        .modal-content {
+            background: var(--bg-100);
+            border-radius: 8px;
+            width: 90%;
+            max-width: 800px;
+            max-height: 90vh;
+            overflow-y: auto;
+        }
+        .modal-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            padding: 1rem 2rem;
+            border-bottom: 1px solid var(--bg-300);
+        }
+        .modal-header h3 {
+            margin: 0;
+        }
+        .modal-close {
+            background: none;
+            border: none;
+            font-size: 1.5rem;
+            cursor: pointer;
+            color: var(--text-200);
+            line-height: 1;
+        }
+        .modal-close:hover {
+            color: var(--text-100);
+        }
+        .modal-body {
+            padding: 1.5rem 2rem;
+        }
+        .modal-footer {
+            display: flex;
+            justify-content: flex-end;
+            gap: 0.75rem;
+            padding: 1rem 2rem;
+            border-top: 1px solid var(--bg-300);
+        }
         .form-row {
             display: flex;
-            gap: 1rem;
+            gap: 1.5rem;
         }
         .form-row .form-group {
             flex: 1;
-            margin-bottom: 0.8rem;
-        }
-        .form-row .form-group.flex-2 {
-            flex: 2;
         }
         .form-group {
-            margin-bottom: 0.8rem;
-        }
-        .collapsible-info {
-            margin-bottom: 1rem;
-        }
-        .collapsible-info summary {
-            cursor: pointer;
-            padding: 0.8rem 1rem;
-            background-color: var(--bg-200);
-            border-left: 4px solid var(--primary);
-            font-weight: 500;
-            user-select: none;
-        }
-        .collapsible-info summary:hover {
-            background-color: var(--bg-300);
-        }
-        .collapsible-info .info-content {
-            padding: 1rem;
-            background-color: var(--bg-100);
-            border-left: 4px solid var(--primary);
-            margin-top: 0;
-        }
-        .collapsible-info ul {
-            margin: 0.5rem 0 0 1.5rem;
-            padding: 0;
-        }
-        .collapsible-info li {
-            margin-bottom: 0.3rem;
+            margin-bottom: 1.25rem;
         }
         .provider-hint {
             font-size: 0.85rem;
             color: var(--text-200);
-            margin-top: 0.25rem;
+            margin-top: -0.5rem;
+            margin-bottom: 1rem;
+        }
+        .test-result {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-radius: 4px;
+            display: none;
+        }
+        .test-result.show {
+            display: block;
+        }
+        .test-result.success {
+            background: rgba(76, 175, 80, 0.1);
+            border: 1px solid var(--success);
+        }
+        .test-result.error {
+            background: rgba(244, 67, 54, 0.1);
+            border: 1px solid var(--danger);
         }
     </style>
 </head>
 <body>
 {% include '_navigation.html' %}
 
-    <div class="container mt-3">
-        <div class="card">
-            <div class="card-header">
-                <span>大模型配置（OpenAI API兼容）</span>
+<div class="container mt-3">
+    <div class="card">
+        <div class="card-header" style="display: flex; justify-content: space-between; align-items: center;">
+            <span>大模型配置管理</span>
+            <button class="btn btn-primary" onclick="openAddModal()">+ 添加配置</button>
+        </div>
+
+        <div style="padding: 1.5rem;">
+            <!-- 配置列表 -->
+            <div id="configList" class="config-list">
+                <!-- 动态加载 -->
             </div>
 
-            <div style="padding: 1.5rem;">
-                <!-- 可折叠的提示信息 -->
-                <details class="collapsible-info">
-                    <summary>ℹ️ 配置说明（点击展开）</summary>
-                    <div class="info-content">
-                        此配置支持所有兼容 OpenAI API 格式的大模型服务，包括：
-                        <ul>
-                            <li><strong>OpenAI</strong> - GPT-4o, GPT-4o-mini, GPT-4 等</li>
-                            <li><strong>阿里云百炼</strong> - qwen-max, qwen-plus, qwq-32b 等</li>
-                            <li><strong>智谱AI</strong> - glm-4, glm-4-flash, glm-4.6 等</li>
-                            <li><strong>DeepSeek</strong> - deepseek-chat, deepseek-coder 等</li>
-                            <li><strong>月之暗面</strong> - moonshot-v1-8k, moonshot-v1-32k 等</li>
-                            <li><strong>豆包大模型</strong> - 需在火山引擎控制台获取模型ID</li>
-                            <li><strong>硅基流动</strong> - 支持多种开源模型</li>
-                            <li><strong>Google Gemini</strong> - gemini-pro, gemini-1.5-flash 等</li>
-                            <li><strong>Ollama</strong> - 本地部署的开源模型</li>
-                        </ul>
-                    </div>
-                </details>
-
-                <form id="llmConfigForm">
-                    <!-- 服务商 + API Base URL 同行 -->
-                    <div class="form-row">
-                        <div class="form-group">
-                            <label class="form-label">服务商</label>
-                            <select id="provider" class="form-control" onchange="onProviderChange()">
-                                <option value="custom">自定义</option>
-                                <option value="openai">OpenAI</option>
-                                <option value="aliyun">阿里云百炼</option>
-                                <option value="zhipu">智谱AI</option>
-                                <option value="deepseek">DeepSeek</option>
-                                <option value="moonshot">月之暗面</option>
-                                <option value="doubao">豆包大模型</option>
-                                <option value="siliconflow">硅基流动</option>
-                                <option value="gemini">Google Gemini</option>
-                                <option value="ollama">Ollama (本地)</option>
-                            </select>
-                        </div>
-                        <div class="form-group flex-2">
-                            <label class="form-label required">API Base URL</label>
-                            <input type="text" id="apiBaseUrl" class="form-control"
-                                   placeholder="https://api.openai.com/v1" required>
-                        </div>
-                    </div>
-                    <div class="provider-hint" id="providerHint" style="margin-top: -0.5rem; margin-bottom: 0.8rem;"></div>
-
-                    <!-- API Key + Model Name 同行 -->
-                    <div class="form-row">
-                        <div class="form-group">
-                            <label class="form-label required">API Key</label>
-                            <input type="password" id="apiKey" class="form-control"
-                                   placeholder="sk-xxxxxxxx" required>
-                        </div>
-                        <div class="form-group">
-                            <label class="form-label required">Model Name</label>
-                            <input type="text" id="modelName" class="form-control"
-                                   placeholder="模型名称" required>
-                        </div>
-                    </div>
-
-                    <!-- Enable Thinking + Enable Stream 同行 -->
-                    <div class="form-row">
-                        <div class="form-group">
-                            <label class="form-label">Thinking</label>
-                            <select id="enableThinking" class="form-control" title="思考模式可能影响JSON输出">
-                                <option value="false">否（默认）</option>
-                                <option value="true">是</option>
-                            </select>
-                        </div>
-                        <div class="form-group">
-                            <label class="form-label">Stream</label>
-                            <select id="enableStream" class="form-control" title="某些模型强制要求启用">
-                                <option value="false">否（默认）</option>
-                                <option value="true">是</option>
-                            </select>
-                        </div>
-                    </div>
-
-                    <!-- 操作按钮 -->
-                    <div class="form-group" style="display: flex; gap: 1rem; justify-content: flex-end; margin-top: 0.5rem;">
-                        <button type="button" class="btn btn-secondary" onclick="testConnection()">测试连接</button>
-                        <button type="submit" class="btn btn-primary">保存配置</button>
-                    </div>
-                </form>
-
-                <!-- 测试结果显示区域 -->
-                <div id="testResult" style="margin-top: 1.5rem; display: none;">
-                    <div class="card">
-                        <div class="card-header">
-                            <span>测试结果</span>
-                        </div>
-                        <div style="padding: 1rem;">
-                            <div id="testResultContent"></div>
-                        </div>
-                    </div>
-                </div>
+            <!-- 空状态 -->
+            <div id="emptyState" class="empty-state" style="display: none;">
+                <p>暂无大模型配置</p>
+                <p>点击上方"添加配置"按钮创建您的第一个大模型配置</p>
             </div>
         </div>
     </div>
+</div>
+
+<!-- 添加/编辑模态框 -->
+<div id="configModal" class="modal-overlay">
+    <div class="modal-content">
+        <div class="modal-header">
+            <h3 id="modalTitle">添加大模型配置</h3>
+            <button class="modal-close" onclick="closeModal()">&times;</button>
+        </div>
+        <div class="modal-body">
+            <form id="configForm">
+                <input type="hidden" id="configId" value="">
+
+                <div class="form-group">
+                    <label class="form-label required">配置名称</label>
+                    <input type="text" id="configName" class="form-control"
+                           placeholder="例如：智谱AI生产环境" required>
+                </div>
+
+                <div class="form-row">
+                    <div class="form-group">
+                        <label class="form-label">服务商</label>
+                        <select id="provider" class="form-control" onchange="onProviderChange()">
+                            <option value="custom">自定义</option>
+                            <option value="openai">OpenAI</option>
+                            <option value="aliyun">阿里云百炼</option>
+                            <option value="zhipu">智谱AI</option>
+                            <option value="deepseek">DeepSeek</option>
+                            <option value="moonshot">月之暗面</option>
+                            <option value="doubao">豆包大模型</option>
+                            <option value="siliconflow">硅基流动</option>
+                            <option value="gemini">Google Gemini</option>
+                            <option value="ollama">Ollama (本地)</option>
+                        </select>
+                    </div>
+                    <div class="form-group" style="flex: 2;">
+                        <label class="form-label required">API Base URL</label>
+                        <input type="text" id="apiBaseUrl" class="form-control"
+                               placeholder="https://api.openai.com/v1" required>
+                    </div>
+                </div>
+                <div class="provider-hint" id="providerHint"></div>
+
+                <div class="form-row">
+                    <div class="form-group">
+                        <label class="form-label required">API Key</label>
+                        <input type="password" id="apiKey" class="form-control"
+                               placeholder="sk-xxxxxxxx" required>
+                    </div>
+                    <div class="form-group">
+                        <label class="form-label required">Model Name</label>
+                        <input type="text" id="modelName" class="form-control"
+                               placeholder="模型名称" required>
+                    </div>
+                </div>
+
+                <div class="form-row">
+                    <div class="form-group">
+                        <label class="form-label">Thinking</label>
+                        <select id="enableThinking" class="form-control" title="思考模式可能影响JSON输出">
+                            <option value="false">否（默认）</option>
+                            <option value="true">是</option>
+                        </select>
+                    </div>
+                    <div class="form-group">
+                        <label class="form-label">Stream</label>
+                        <select id="enableStream" class="form-control" title="某些模型强制要求启用">
+                            <option value="false">否（默认）</option>
+                            <option value="true">是</option>
+                        </select>
+                    </div>
+                </div>
+
+                <!-- 测试结果 -->
+                <div id="testResult" class="test-result">
+                    <div id="testResultContent"></div>
+                </div>
+            </form>
+        </div>
+        <div class="modal-footer">
+            <button type="button" id="testBtn" class="btn btn-secondary" onclick="testConnection()">测试连接</button>
+            <button type="button" class="btn btn-secondary" onclick="closeModal()">取消</button>
+            <button type="button" class="btn btn-primary" onclick="saveConfig()">保存</button>
+        </div>
+    </div>
+</div>
 
 {% include '_footer.html' %}
 
-    <script>
-        let originalApiKey = null;
+<script>
+    // 服务商配置
+    const providers = {
+        'custom': { url: '', hint: '请手动填写 API 地址' },
+        'openai': { url: 'https://api.openai.com/v1', hint: '常用模型：gpt-4o, gpt-4o-mini, gpt-4-turbo' },
+        'aliyun': { url: 'https://dashscope.aliyuncs.com/compatible-mode/v1', hint: '常用模型：qwen-max, qwen-plus, qwq-32b' },
+        'zhipu': { url: 'https://open.bigmodel.cn/api/paas/v4', hint: '常用模型：glm-4, glm-4-flash, glm-4.6' },
+        'deepseek': { url: 'https://api.deepseek.com/v1', hint: '常用模型：deepseek-chat, deepseek-coder' },
+        'moonshot': { url: 'https://api.moonshot.cn/v1', hint: '常用模型：moonshot-v1-8k, moonshot-v1-32k, moonshot-v1-128k' },
+        'doubao': { url: 'https://ark.cn-beijing.volces.com/api/v3', hint: '模型ID需在火山引擎控制台创建推理接入点获取' },
+        'siliconflow': { url: 'https://api.siliconflow.cn/v1', hint: '支持 Qwen、DeepSeek、Llama 等多种开源模型' },
+        'gemini': { url: 'https://generativelanguage.googleapis.com/v1beta/openai', hint: '常用模型：gemini-1.5-flash, gemini-1.5-pro, gemini-pro' },
+        'ollama': { url: 'http://localhost:11434/v1', hint: '本地部署，模型名称与 ollama list 显示的一致' }
+    };
 
-        // 服务商配置
-        const providers = {
-            'custom': {
-                url: '',
-                hint: '请手动填写 API 地址'
-            },
-            'openai': {
-                url: 'https://api.openai.com/v1',
-                hint: '常用模型：gpt-4o, gpt-4o-mini, gpt-4-turbo'
-            },
-            'aliyun': {
-                url: 'https://dashscope.aliyuncs.com/compatible-mode/v1',
-                hint: '常用模型：qwen-max, qwen-plus, qwq-32b'
-            },
-            'zhipu': {
-                url: 'https://open.bigmodel.cn/api/paas/v4',
-                hint: '常用模型：glm-4, glm-4-flash, glm-4.6'
-            },
-            'deepseek': {
-                url: 'https://api.deepseek.com/v1',
-                hint: '常用模型：deepseek-chat, deepseek-coder'
-            },
-            'moonshot': {
-                url: 'https://api.moonshot.cn/v1',
-                hint: '常用模型：moonshot-v1-8k, moonshot-v1-32k, moonshot-v1-128k'
-            },
-            'doubao': {
-                url: 'https://ark.cn-beijing.volces.com/api/v3',
-                hint: '模型ID需在火山引擎控制台创建推理接入点获取'
-            },
-            'siliconflow': {
-                url: 'https://api.siliconflow.cn/v1',
-                hint: '支持 Qwen、DeepSeek、Llama 等多种开源模型'
-            },
-            'gemini': {
-                url: 'https://generativelanguage.googleapis.com/v1beta/openai',
-                hint: '常用模型：gemini-1.5-flash, gemini-1.5-pro, gemini-pro'
-            },
-            'ollama': {
-                url: 'http://localhost:11434/v1',
-                hint: '本地部署，模型名称与 ollama list 显示的一致'
+    let currentConfigs = [];
+
+    // 页面加载
+    document.addEventListener('DOMContentLoaded', loadConfigs);
+
+    // 加载所有配置
+    async function loadConfigs() {
+        try {
+            const response = await fetch('/admin/api/llm-configs');
+            const data = await response.json();
+            currentConfigs = data.configs || [];
+            renderConfigList();
+        } catch (error) {
+            console.error('Failed to load configs:', error);
+            alert('加载配置失败');
+        }
+    }
+
+    // 渲染配置列表
+    function renderConfigList() {
+        const listEl = document.getElementById('configList');
+        const emptyEl = document.getElementById('emptyState');
+
+        if (currentConfigs.length === 0) {
+            listEl.style.display = 'none';
+            emptyEl.style.display = 'block';
+            return;
+        }
+
+        listEl.style.display = 'flex';
+        emptyEl.style.display = 'none';
+
+        listEl.innerHTML = currentConfigs.map(config => `
+            <div class="config-card ${config.is_active ? 'active' : ''}">
+                <div class="config-header">
+                    <div class="config-title">
+                        <span class="status-icon">${config.is_active ? '✅' : '○'}</span>
+                        <span>${escapeHtml(config.name)}</span>
+                        <span style="color: var(--text-200); font-weight: normal;">- ${escapeHtml(config.model_name)}</span>
+                        ${config.is_active ? '<span class="active-badge">已启用</span>' : ''}
+                    </div>
+                    <div class="config-actions">
+                        ${!config.is_active && currentConfigs.length > 1 ?
+                            `<button class="btn btn-success" onclick="activateConfig(${config.id})">启用</button>` : ''}
+                        <button class="btn btn-secondary" onclick="editConfig(${config.id})">编辑</button>
+                        <button class="btn btn-danger" onclick="deleteConfig(${config.id}, '${escapeHtml(config.name)}')">删除</button>
+                    </div>
+                </div>
+                <div class="config-details">
+                    <span class="detail-item">${escapeHtml(config.api_base_url)}</span>
+                    <span class="detail-item">API Key: ${config.api_key || '未配置'}</span>
+                    <span class="detail-item">Stream: ${config.enable_stream ? '是' : '否'}</span>
+                    <span class="detail-item">Thinking: ${config.enable_thinking ? '是' : '否'}</span>
+                </div>
+            </div>
+        `).join('');
+    }
+
+    // 打开添加模态框
+    function openAddModal() {
+        document.getElementById('modalTitle').textContent = '添加大模型配置';
+        document.getElementById('configId').value = '';
+        document.getElementById('configForm').reset();
+        document.getElementById('provider').value = 'custom';
+        document.getElementById('providerHint').textContent = '';
+        hideTestResult();
+        showModal();
+    }
+
+    // 编辑配置
+    function editConfig(id) {
+        const config = currentConfigs.find(c => c.id === id);
+        if (!config) return;
+
+        document.getElementById('modalTitle').textContent = '编辑大模型配置';
+        document.getElementById('configId').value = id;
+        document.getElementById('configName').value = config.name;
+        document.getElementById('apiBaseUrl').value = config.api_base_url;
+        document.getElementById('apiKey').value = config.api_key || '';
+        document.getElementById('modelName').value = config.model_name;
+        document.getElementById('enableThinking').value = config.enable_thinking ? 'true' : 'false';
+        document.getElementById('enableStream').value = config.enable_stream ? 'true' : 'false';
+
+        // 检测服务商
+        const provider = detectProvider(config.api_base_url);
+        document.getElementById('provider').value = provider;
+        onProviderChange();
+
+        hideTestResult();
+        showModal();
+    }
+
+    // 删除配置
+    async function deleteConfig(id, name) {
+        if (!confirm(`确定要删除配置"${name}"吗？`)) return;
+
+        try {
+            const response = await fetch(`/admin/api/llm-configs/${id}`, {
+                method: 'DELETE'
+            });
+            const result = await response.json();
+
+            if (response.ok) {
+                loadConfigs();
+            } else {
+                alert('删除失败: ' + (result.error || '未知错误'));
             }
+        } catch (error) {
+            alert('删除失败: ' + error.message);
+        }
+    }
+
+    // 启用配置
+    async function activateConfig(id) {
+        try {
+            const response = await fetch(`/admin/api/llm-configs/${id}/activate`, {
+                method: 'POST'
+            });
+            const result = await response.json();
+
+            if (response.ok) {
+                loadConfigs();
+            } else {
+                alert('启用失败: ' + (result.error || '未知错误'));
+            }
+        } catch (error) {
+            alert('启用失败: ' + error.message);
+        }
+    }
+
+    // 保存配置
+    async function saveConfig() {
+        const id = document.getElementById('configId').value;
+        const data = {
+            name: document.getElementById('configName').value,
+            api_key: document.getElementById('apiKey').value,
+            api_base_url: document.getElementById('apiBaseUrl').value,
+            model_name: document.getElementById('modelName').value,
+            enable_thinking: document.getElementById('enableThinking').value === 'true',
+            enable_stream: document.getElementById('enableStream').value === 'true'
         };
 
-        // 服务商选择变化
-        function onProviderChange() {
-            const provider = document.getElementById('provider').value;
-            const config = providers[provider];
-
-            if (config) {
-                if (config.url) {
-                    document.getElementById('apiBaseUrl').value = config.url;
-                }
-                document.getElementById('providerHint').textContent = config.hint;
-            }
+        if (!data.name) {
+            alert('请填写配置名称');
+            return;
         }
 
-        // 根据 URL 反推服务商
-        function detectProvider(url) {
-            if (!url) return 'custom';
-            for (const [key, config] of Object.entries(providers)) {
-                if (config.url && url.includes(new URL(config.url).host)) {
-                    return key;
-                }
+        try {
+            const url = id ? `/admin/api/llm-configs/${id}` : '/admin/api/llm-configs';
+            const method = id ? 'PUT' : 'POST';
+
+            const response = await fetch(url, {
+                method: method,
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(data)
+            });
+
+            const result = await response.json();
+
+            if (response.ok) {
+                closeModal();
+                loadConfigs();
+            } else {
+                alert('保存失败: ' + (result.error || '未知错误'));
             }
-            return 'custom';
+        } catch (error) {
+            alert('保存失败: ' + error.message);
+        }
+    }
+
+    // 测试连接
+    async function testConnection() {
+        const testBtn = document.getElementById('testBtn');
+        const configId = document.getElementById('configId').value;
+        const data = {
+            api_key: document.getElementById('apiKey').value,
+            api_base_url: document.getElementById('apiBaseUrl').value,
+            model_name: document.getElementById('modelName').value,
+            enable_thinking: document.getElementById('enableThinking').value === 'true',
+            enable_stream: document.getElementById('enableStream').value === 'true'
+        };
+
+        // 编辑模式下传入配置ID，用于从数据库获取真实的API Key
+        if (configId) {
+            data.config_id = parseInt(configId);
         }
 
-        // 页面加载时初始化
-        document.addEventListener('DOMContentLoaded', function() {
-            loadConfig();
-        });
-
-        // 加载配置
-        async function loadConfig() {
-            try {
-                const response = await fetch('/admin/api/llm-config');
-                const config = await response.json();
-
-                if (config.api_key) {
-                    originalApiKey = config.api_key;
-                    document.getElementById('apiKey').value = config.api_key;
-                    document.getElementById('apiKey').placeholder = '已配置（保持原值请勿修改）';
-                }
-
-                const apiBaseUrl = config.api_base_url || 'https://api.openai.com/v1';
-                document.getElementById('apiBaseUrl').value = apiBaseUrl;
-                document.getElementById('modelName').value = config.model_name || '';
-                document.getElementById('enableThinking').value = config.enable_thinking ? 'true' : 'false';
-                document.getElementById('enableStream').value = config.enable_stream ? 'true' : 'false';
-
-                // 根据 URL 自动选择服务商
-                const provider = detectProvider(apiBaseUrl);
-                document.getElementById('provider').value = provider;
-                onProviderChange();
-            } catch (error) {
-                console.error('Failed to load config:', error);
-                alert('加载配置失败');
-            }
+        if (!data.api_key || !data.api_base_url || !data.model_name) {
+            alert('请填写完整的配置信息');
+            return;
         }
 
-        // 提交表单
-        document.getElementById('llmConfigForm').addEventListener('submit', async function(e) {
-            e.preventDefault();
+        // 禁用测试按钮
+        testBtn.disabled = true;
+        testBtn.textContent = '测试中...';
+        showTestResult('testing', '<span style="color: var(--primary);">测试中，请稍候...</span>');
 
-            const apiKey = document.getElementById('apiKey').value;
-            const apiBaseUrl = document.getElementById('apiBaseUrl').value;
-            const modelName = document.getElementById('modelName').value;
-            const enableThinking = document.getElementById('enableThinking').value === 'true';
-            const enableStream = document.getElementById('enableStream').value === 'true';
+        try {
+            const response = await fetch('/admin/api/llm-config/test', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(data)
+            });
 
-            const finalApiKey = apiKey === originalApiKey ? originalApiKey : apiKey;
+            const result = await response.json();
 
-            const data = {
-                api_key: finalApiKey,
-                api_base_url: apiBaseUrl,
-                model_name: modelName,
-                enable_thinking: enableThinking,
-                enable_stream: enableStream
-            };
-
-            try {
-                const response = await fetch('/admin/api/llm-config', {
-                    method: 'POST',
-                    headers: {
-                        'Content-Type': 'application/json'
-                    },
-                    body: JSON.stringify(data)
-                });
-
-                const result = await response.json();
-
-                if (response.ok) {
-                    alert(result.message || '配置保存成功');
-                    loadConfig();
-                } else {
-                    alert('保存失败: ' + (result.error || '未知错误'));
-                }
-            } catch (error) {
-                console.error('Failed to save config:', error);
-                alert('保存失败');
-            }
-        });
-
-        // 测试连接
-        async function testConnection() {
-            const apiKey = document.getElementById('apiKey').value;
-            const apiBaseUrl = document.getElementById('apiBaseUrl').value;
-            const modelName = document.getElementById('modelName').value;
-            const enableThinking = document.getElementById('enableThinking').value === 'true';
-            const enableStream = document.getElementById('enableStream').value === 'true';
-
-            if (!apiKey || !apiBaseUrl || !modelName) {
-                alert('请填写完整的配置信息');
-                return;
-            }
-
-            const testResult = document.getElementById('testResult');
-            const testResultContent = document.getElementById('testResultContent');
-            testResult.style.display = 'block';
-            testResultContent.innerHTML = '<div style="text-align: center; padding: 1rem;"><span style="color: var(--primary);">测试中，请稍候...</span></div>';
-
-            const data = {
-                api_key: apiKey,
-                api_base_url: apiBaseUrl,
-                model_name: modelName,
-                enable_thinking: enableThinking,
-                enable_stream: enableStream
-            };
-
-            try {
-                const response = await fetch('/admin/api/llm-config/test', {
-                    method: 'POST',
-                    headers: {
-                        'Content-Type': 'application/json'
-                    },
-                    body: JSON.stringify(data)
-                });
-
-                const result = await response.json();
-
-                if (result.success) {
-                    const responseText = result.response || '(模型未返回内容，但连接成功)';
-                    testResultContent.innerHTML = `
-                        <div style="color: var(--success);">
-                            <strong>✓ ${result.message}</strong>
-                            <div style="margin-top: 0.5rem; padding: 0.8rem; background-color: var(--bg-200); border-radius: 4px;">
-                                <div style="margin-bottom: 0.5rem;"><strong>模型：</strong>${result.model}</div>
-                                <div style="margin-bottom: 0.5rem;"><strong>响应时间：</strong>${result.duration}</div>
-                                <div style="margin-bottom: 0.3rem;"><strong>模型响应：</strong></div>
-                                <div style="padding: 0.5rem; background-color: var(--bg-100); border-left: 3px solid var(--primary); white-space: pre-wrap; word-break: break-word;">${responseText}</div>
-                            </div>
-                        </div>
-                    `;
-                } else {
-                    testResultContent.innerHTML = `
-                        <div style="color: var(--danger);">
-                            <strong>✗ 测试失败</strong>
-                            <div style="margin-top: 0.5rem; padding: 0.8rem; background-color: var(--bg-200); border-radius: 4px; color: var(--text-100);">
-                                ${result.error || '未知错误'}
-                            </div>
-                        </div>
-                    `;
-                }
-            } catch (error) {
-                console.error('Test failed:', error);
-                testResultContent.innerHTML = `
-                    <div style="color: var(--danger);">
-                        <strong>✗ 测试失败</strong>
-                        <div style="margin-top: 0.5rem; padding: 0.8rem; background-color: var(--bg-200); border-radius: 4px; color: var(--text-100);">
-                            ${error.message || '网络错误'}
-                        </div>
+            if (result.success) {
+                showTestResult('success', `
+                    <strong>✓ ${result.message}</strong><br>
+                    <small>模型: ${result.model} | 响应时间: ${result.duration}</small><br>
+                    <div style="margin-top: 0.5rem; padding: 0.5rem; background: var(--bg-200); border-radius: 4px;">
+                        ${escapeHtml(result.response || '(无响应内容)')}
                     </div>
-                `;
+                `);
+            } else {
+                showTestResult('error', `<strong>✗ 测试失败</strong><br>${escapeHtml(result.error)}`);
+            }
+        } catch (error) {
+            showTestResult('error', `<strong>✗ 测试失败</strong><br>${escapeHtml(error.message)}`);
+        } finally {
+            // 恢复测试按钮
+            testBtn.disabled = false;
+            testBtn.textContent = '测试连接';
+        }
+    }
+
+    // 服务商选择变化
+    function onProviderChange() {
+        const provider = document.getElementById('provider').value;
+        const config = providers[provider];
+        if (config) {
+            if (config.url) {
+                document.getElementById('apiBaseUrl').value = config.url;
+            }
+            document.getElementById('providerHint').textContent = config.hint;
+        }
+    }
+
+    // 根据 URL 反推服务商
+    function detectProvider(url) {
+        if (!url) return 'custom';
+        for (const [key, config] of Object.entries(providers)) {
+            if (config.url && url.includes(new URL(config.url).host)) {
+                return key;
             }
         }
-    </script>
+        return 'custom';
+    }
+
+    // 显示/隐藏模态框
+    function showModal() {
+        document.getElementById('configModal').classList.add('show');
+    }
+
+    function closeModal() {
+        document.getElementById('configModal').classList.remove('show');
+    }
+
+    // 测试结果显示
+    function showTestResult(type, content) {
+        const el = document.getElementById('testResult');
+        const contentEl = document.getElementById('testResultContent');
+        el.className = 'test-result show ' + (type === 'success' ? 'success' : type === 'error' ? 'error' : '');
+        contentEl.innerHTML = content;
+    }
+
+    function hideTestResult() {
+        document.getElementById('testResult').className = 'test-result';
+    }
+
+    // HTML转义
+    function escapeHtml(text) {
+        if (!text) return '';
+        const div = document.createElement('div');
+        div.textContent = text;
+        return div.innerHTML;
+    }
+
+    // 点击模态框外部关闭
+    document.getElementById('configModal').addEventListener('click', function(e) {
+        if (e.target === this) closeModal();
+    });
+
+    // ESC键关闭模态框
+    document.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape') closeModal();
+    });
+</script>
 </body>
 </html>

--- a/version.py
+++ b/version.py
@@ -3,11 +3,23 @@
 UniMCPSim Version Information
 """
 
-__version__ = "2.10.1"
-__version_info__ = (2, 10, 1)
+__version__ = "2.11.0"
+__version_info__ = (2, 11, 0)
 
 # Version history
 VERSION_HISTORY = {
+    "2.11.0": {
+        "date": "2025-12-12",
+        "features": [
+            "多LLM配置管理（预注册多个大模型配置）",
+            "配置卡片列表展示，一键切换活跃配置",
+            "配置热切换（跨进程自动同步，无需重启）",
+            "增强JSON解析（支持多JSON对象、Extra data等格式问题）",
+            "推理模型空响应智能提示（提示启用Stream模式）",
+            "测试连接按钮禁用状态优化",
+            "编辑配置时自动获取数据库中的API Key"
+        ]
+    },
     "2.10.1": {
         "date": "2025-12-12",
         "features": [


### PR DESCRIPTION
## Summary
同步 main 分支 v2.11.0 版本的多LLM配置管理功能至 OEM 分支。

### 主要更新
- 多LLM配置管理（预注册多个大模型配置，卡片列表展示）
- 一键切换活跃配置，第一个配置自动启用
- 配置热切换（MCP Server自动检测数据库配置变化，无需重启）
- 增强JSON解析（支持多JSON对象、Extra data等格式问题）
- 推理模型空响应智能提示（提示启用Stream模式）
- 修复SQLAlchemy Session错误、测试连接API Key获取等问题

## Test plan
- [x] 验证OEM白标功能正常
- [x] 验证多LLM配置管理功能
- [x] 验证配置热切换功能

🤖 Generated with [Claude Code](https://claude.com/claude-code)