### PR TITLE
Claude/fix test connection button 01 s2 a lv ro lqp xb538 lggz2d h

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.11.1] - 2025-12-13
+
+### Fixed
+- Button disabled state now has visual feedback (opacity, cursor change)
+- "Test Connection" button in LLM config page shows disabled state during testing
+- "Auto Generate Actions" button in apps page shows disabled state during AI generation
+- Fixed AI generate button not re-enabled after successful generation
+
 ## [2.11.0] - 2025-12-12
 
 ### Added

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -233,6 +233,13 @@ body {
     font-size: 0.875rem;
 }
 
+.btn:disabled,
+.btn[disabled] {
+    opacity: 0.6;
+    cursor: not-allowed;
+    pointer-events: none;
+}
+
 /* Table Styles */
 .table {
     width: 100%;

--- a/templates/apps.html
+++ b/templates/apps.html
@@ -617,7 +617,7 @@
 
                     // 恢复按钮状态
                     button.textContent = originalText;
-                    // 保持按钮启用状态(蓝色)，因为提示词还在
+                    button.disabled = false;  // 保持按钮启用状态，因为提示词还在
                 } else {
                     showNotification('生成失败：' + result.error, 'error');
                     // 失败时也恢复按钮

--- a/version.py
+++ b/version.py
@@ -3,11 +3,20 @@
 UniMCPSim Version Information
 """
 
-__version__ = "2.11.0"
-__version_info__ = (2, 11, 0)
+__version__ = "2.11.1"
+__version_info__ = (2, 11, 1)
 
 # Version history
 VERSION_HISTORY = {
+    "2.11.1": {
+        "date": "2025-12-13",
+        "features": [
+            "修复按钮禁用状态无视觉反馈的问题",
+            "测试连接按钮在测试中显示禁用样式",
+            "AI生成按钮在生成中显示禁用样式",
+            "修复AI生成成功后按钮未恢复启用状态"
+        ]
+    },
     "2.11.0": {
         "date": "2025-12-12",
         "features": [


### PR DESCRIPTION
## Summary
- 添加按钮禁用状态的 CSS 样式（opacity、cursor、pointer-events）
- 修复"测试连接"按钮在测试中无视觉禁用反馈的问题
- 修复"AI生成动作定义"按钮在生成中无视觉禁用反馈的问题
- 修复 AI 生成成功后按钮未恢复启用状态的 bug

## Test plan
- [ ] 访问 /admin/llm-config 页面，点击"测试连接"按钮，确认按钮变灰且不可点击
- [ ] 访问 /admin/apps 页面，创建应用时点击"自动生成动作定义"按钮，确认按钮变灰且不可点击
- [ ] 确认操作完成后按钮恢复正常状态
