### PR TITLE
fix: 修复非localhost HTTP环境下剪贴板复制失败问题 (v2.12.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.12.2] - 2025-12-13
+
+### Fixed
+- Fixed clipboard copy failure in non-localhost HTTP environments (navigator.clipboard API requires secure context)
+- Token management page copy function now works via IP address access
+- App management page MCP config copy function now works via IP address access
+
+### Added
+- Fallback copy mechanism using document.execCommand for legacy browsers and non-secure contexts
+
 ## [2.12.1] - 2025-12-13
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -399,7 +399,7 @@ LOG_LEVEL=INFO
 
 ## Project Status
 
-Current Version: **v2.12.1**
+Current Version: **v2.12.2**
 - ✅ Core MCP simulator fully functional
 - ✅ Pre-configured product simulators
 - ✅ AI-enhanced response generation

--- a/templates/apps.html
+++ b/templates/apps.html
@@ -834,14 +834,48 @@
             document.getElementById('mcpConfigModal').classList.remove('show');
         }
 
+        function fallbackCopyToClipboard(text) {
+            const textArea = document.createElement('textarea');
+            textArea.value = text;
+            textArea.style.position = 'fixed';
+            textArea.style.left = '-9999px';
+            textArea.style.top = '-9999px';
+            document.body.appendChild(textArea);
+            textArea.focus();
+            textArea.select();
+            try {
+                document.execCommand('copy');
+                return true;
+            } catch (err) {
+                console.error('Fallback copy failed:', err);
+                return false;
+            } finally {
+                document.body.removeChild(textArea);
+            }
+        }
+
         function copyMcpConfig() {
             const text = document.getElementById('mcpConfigText').value;
-            navigator.clipboard.writeText(text).then(() => {
-                alert('MCP配置已复制到剪贴板！\n\n请记得替换 YOUR_TOKEN_HERE 为实际的token值（从Token管理页面获取）');
-            }).catch(err => {
-                console.error('Failed to copy:', err);
-                alert('复制失败，请手动选择复制');
-            });
+            const successMsg = 'MCP配置已复制到剪贴板！\n\n请记得替换 YOUR_TOKEN_HERE 为实际的token值（从Token管理页面获取）';
+
+            if (navigator.clipboard && navigator.clipboard.writeText) {
+                navigator.clipboard.writeText(text).then(() => {
+                    alert(successMsg);
+                }).catch(err => {
+                    console.error('Clipboard API failed:', err);
+                    if (fallbackCopyToClipboard(text)) {
+                        alert(successMsg);
+                    } else {
+                        alert('复制失败，请手动选择复制');
+                    }
+                });
+            } else {
+                if (fallbackCopyToClipboard(text)) {
+                    alert(successMsg);
+                } else {
+                    alert('复制失败，请手动选择复制');
+                }
+            }
         }
 
         // ========== 导出功能 ==========

--- a/templates/tokens.html
+++ b/templates/tokens.html
@@ -227,15 +227,54 @@
             loadTokens();
         }
 
+        function fallbackCopyToClipboard(text) {
+            const textArea = document.createElement('textarea');
+            textArea.value = text;
+            textArea.style.position = 'fixed';
+            textArea.style.left = '-9999px';
+            textArea.style.top = '-9999px';
+            document.body.appendChild(textArea);
+            textArea.focus();
+            textArea.select();
+            try {
+                document.execCommand('copy');
+                return true;
+            } catch (err) {
+                console.error('Fallback copy failed:', err);
+                return false;
+            } finally {
+                document.body.removeChild(textArea);
+            }
+        }
+
+        function copyToClipboard(text, successMsg) {
+            if (navigator.clipboard && navigator.clipboard.writeText) {
+                navigator.clipboard.writeText(text).then(() => {
+                    alert(successMsg);
+                }).catch(err => {
+                    console.error('Clipboard API failed:', err);
+                    if (fallbackCopyToClipboard(text)) {
+                        alert(successMsg);
+                    } else {
+                        alert('复制失败，请手动复制');
+                    }
+                });
+            } else {
+                if (fallbackCopyToClipboard(text)) {
+                    alert(successMsg);
+                } else {
+                    alert('复制失败，请手动复制');
+                }
+            }
+        }
+
         function copyTokenValue(token) {
-            navigator.clipboard.writeText(token);
-            alert('Token已复制到剪贴板');
+            copyToClipboard(token, 'Token已复制到剪贴板');
         }
 
         function copyToken() {
             const token = document.getElementById('newTokenValue').value;
-            navigator.clipboard.writeText(token);
-            alert('Token已复制到剪贴板');
+            copyToClipboard(token, 'Token已复制到剪贴板');
         }
 
         async function showPermissions(tokenId) {

--- a/version.py
+++ b/version.py
@@ -3,11 +3,20 @@
 UniMCPSim Version Information
 """
 
-__version__ = "2.12.1"
-__version_info__ = (2, 12, 1)
+__version__ = "2.12.2"
+__version_info__ = (2, 12, 2)
 
 # Version history
 VERSION_HISTORY = {
+    "2.12.2": {
+        "date": "2025-12-13",
+        "features": [
+            "修复非localhost HTTP环境下剪贴板复制失败问题",
+            "Token管理页面复制功能兼容性修复",
+            "应用管理页面MCP配置复制功能兼容性修复",
+            "添加document.execCommand回退方案支持旧浏览器和非安全上下文"
+        ]
+    },
     "2.12.1": {
         "date": "2025-12-13",
         "features": [


### PR DESCRIPTION
## Summary
- 修复 Token 管理页面复制功能在非 localhost HTTP 环境下失败的问题
- 修复应用管理页面 MCP 配置复制功能在非 localhost HTTP 环境下失败的问题
- 添加 `document.execCommand` 回退方案支持旧浏览器和非安全上下文

## 问题原因
`navigator.clipboard` API 仅在安全上下文（Secure Context）中可用：
- `localhost` 或 `127.0.0.1`
- HTTPS 连接

通过 IP 地址的 HTTP 访问（如 `http://192.168.x.x:9091`）时，`navigator.clipboard` 为 `undefined`，导致复制功能报错。

## 解决方案
添加 `fallbackCopyToClipboard()` 函数作为回退方案，使用传统的 `document.execCommand('copy')` 方法。

## Test plan
- [x] 通过 localhost 访问测试复制功能
- [x] 通过 IP 地址 HTTP 访问测试复制功能

🤖 Generated with [Claude Code](https://claude.com/claude-code)